### PR TITLE
PR: Adding xml tags to the detectImage function to detect custom image windows version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,16 @@ docker run -it --rm --name windows -p 8006:8006 --device=/dev/kvm --cap-add NET_
 
   Replace the example path `/home/user/custom.xml` with the filename of the modified XML file.
 
+
+  NOTE: If you are using a custom image (custom.iso) you can customize the settings for the automatic isntallation by providing a custom.xml file in your compose file. For example, add the following line inside your compose file:
+
+  ```yaml
+  volumes:
+    -  /home/user/custom.xml:/run/assets/custom.xml
+  ```
+  
+  Replace the example path `/home/user/custom.xml` with the filename of the modified XML file.
+
 * ### How do I run a script after installation?
 
   To run your own script after installation, you can create a file called `install.bat` and place it in a folder together with other files it needs (programs to install for example). Then bind it in your compose file like this:

--- a/readme.md
+++ b/readme.md
@@ -180,16 +180,6 @@ docker run -it --rm --name windows -p 8006:8006 --device=/dev/kvm --cap-add NET_
 
   Replace the example path `/home/user/custom.xml` with the filename of the modified XML file.
 
-
-  NOTE: If you are using a custom image (custom.iso) you can customize the settings for the automatic isntallation by providing a custom.xml file in your compose file. For example, add the following line inside your compose file:
-
-  ```yaml
-  volumes:
-    -  /home/user/custom.xml:/run/assets/custom.xml
-  ```
-  
-  Replace the example path `/home/user/custom.xml` with the filename of the modified XML file.
-
 * ### How do I run a script after installation?
 
   To run your own script after installation, you can create a file called `install.bat` and place it in a folder together with other files it needs (programs to install for example). Then bind it in your compose file like this:

--- a/src/install.sh
+++ b/src/install.sh
@@ -533,7 +533,11 @@ detectImage() {
   local dir="$1"
 
   if [ -n "$CUSTOM" ]; then
-    DETECTED=""
+    if [ -f "/run/assets/custom.xml" ]; then
+      DETECTED="custom"
+    else
+      DETECTED=""
+    fi
   else
     if [ -z "$DETECTED" ] && [[ "$EXTERNAL" != [Yy1]* ]]; then
       DETECTED="$VERSION"

--- a/src/install.sh
+++ b/src/install.sh
@@ -607,6 +607,24 @@ detectImage() {
   fi
 
   if [ -z "$DETECTED" ]; then
+
+    tag="NAME"
+    name3=$(sed -n "/$tag/{s/.*<$tag>\(.*\)<\/$tag>.*/\1/;p}" <<< "$result")
+    [ -z "$name" ] && name="$name3"
+    DETECTED=$(getVersion "$name3")
+
+  fi
+
+  if [ -z "$DETECTED" ]; then
+
+    tag="DESCRIPTION"
+    name4=$(sed -n "/$tag/{s/.*<$tag>\(.*\)<\/$tag>.*/\1/;p}" <<< "$result")
+    [ -z "$name" ] && name="$name4"
+    DETECTED=$(getVersion "$name4")
+
+  fi
+
+  if [ -z "$DETECTED" ]; then
     warn "failed to determine Windows version from string '$name', $FB" && return 0
   fi
 


### PR DESCRIPTION
For your consideration. 

If you want I can type up a readme section that talks about custom iso files using the ```dism /CaptureImage``` command and how it's important to populate the correct windows version into the ```name``` and ```description``` flags. 

Now that I understand better, I will start creating my custom iso files with the naming conventions as required in the 'getVersion' function.

Thanks
-Addison