### PR TITLE
Optionally disable creation of readme.txt on the shared folder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,13 @@ kubectl apply -f kubernetes.yml
 
   The example folder `/home/user/example` will be available as ` \\host.lan\Data`. You can optionally map this path to a drive letter in Windows, for easier access.
 
+  At boot, the file `readme.txt` will be created on the folder unless you disable it:
+
+  ```yaml
+  environment:
+    README: "N"
+  ```
+
 * ### How do I install a custom image?
 
   In order to download an unsupported ISO image that is not selectable from the list above, specify the URL of that ISO in the `VERSION` environment variable, for example:

--- a/src/define.sh
+++ b/src/define.sh
@@ -11,6 +11,7 @@ set -Eeuo pipefail
 : "${LANGUAGE:=""}"
 : "${USERNAME:=""}"
 : "${PASSWORD:=""}"
+: "${README:=""}"
 
 MIRRORS=5
 PLATFORM="x64"

--- a/src/samba.sh
+++ b/src/samba.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+: "${README:="Y"}"
 : "${SAMBA:="Y"}"
 
 [[ "$SAMBA" != [Yy1]* ]] && return 0
@@ -50,25 +51,27 @@ mkdir -p "$share"
         echo "    force group = root"
 } > "/etc/samba/smb.conf"
 
-{      echo "--------------------------------------------------------"
-        echo " $APP for Docker v$(</run/version)..."
-        echo " For support visit $SUPPORT"
-        echo "--------------------------------------------------------"
-        echo ""
-        echo "Using this folder you can share files with the host machine."
-        echo ""
-        echo "To change its location, include the following bind mount in your compose file:"
-        echo ""
-        echo "  volumes:"
-        echo "    - \"/home/user/example:/shared\""
-        echo ""
-        echo "Or in your run command:"
-        echo ""
-        echo "  -v \"/home/user/example:/shared\""
-        echo ""
-        echo "Replace the example path /home/user/example with the desired shared folder."
-        echo ""
-} | unix2dos > "$share/readme.txt"
+if [[ "$README" == [Yy1]* ]] ;then
+  { echo "--------------------------------------------------------"
+    echo " $APP for Docker v$(</run/version)..."
+    echo " For support visit $SUPPORT"
+    echo "--------------------------------------------------------"
+    echo ""
+    echo "Using this folder you can share files with the host machine."
+    echo ""
+    echo "To change its location, include the following bind mount in your compose file:"
+    echo ""
+    echo "  volumes:"
+    echo "    - \"/home/user/example:/shared\""
+    echo ""
+    echo "Or in your run command:"
+    echo ""
+    echo "  -v \"/home/user/example:/shared\""
+    echo ""
+    echo "Replace the example path /home/user/example with the desired shared folder."
+    echo ""
+  } | unix2dos > "$share/readme.txt"
+fi
 
 ! smbd && smbd --debug-stdout
 


### PR DESCRIPTION
## Summary

This PR allows the users to avoid the file 'readme.txt' being created in the shared folder.

## Details

Actually, after booting the cointainer and if it has a folder shared from the host, a small `readme.txt` file is created.  This PR makes this behaviour completely configurable by means of a new variable (`README`) that can be defined in `compose.yml`:

```yaml
environment:
  README: "N"
```

The new variable `README` defaults to "Y" so that the default behaviour does not change  (but, from my point of view, it should be set as "N" -- that is, disable the automatic creation of an new, possibly unwanted file).

## Testing
1.- Add both the variable `README="N"` and a shared folder to compose.yml
2.- Start the container
3.- Check, either from the host or from within the container, the shared folder.  The file `readme.txt` should not have been created.