### PR TITLE
add ghcr badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@
 <div align="center">
 
 [![Build]][build_url]
+[![GHCR Pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fipitio%2Fghcr-pulls%2Fmaster%2Findex.json&query=%24%5B%3F(%40.owner%3D%3D%22dockur%22%20%26%26%20%40.repo%3D%3D%22windows%22%20%26%26%20%40.image%3D%3D%22windows%22)%5D.pulls&logo=github&label=Pulls)](https://github.com/dockur/windows/pkgs/container/windows)
 [![Version]][tag_url]
 [![Size]][tag_url]
 [![Pulls]][hub_url]


### PR DESCRIPTION
ghcr.io's api doesn't let you see the pull count so I created [ghcr-pulls](https://github.com/ipitio/ghcr-pulls), a daily scraper that updates the count and makes this badge possible. I noticed that you use ghcr and have a docker hub counter and thought you might find this useful.