### PR TITLE
fixed node port out of range for 48006 and removed kubevirt dep

### DIFF
--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -27,9 +27,6 @@ spec:
           protocol: TCP
         - containerPort: 3389
           protocol: UDP
-      resources:
-        limits:
-          devices.kubevirt.io/kvm: 1
       securityContext:
         privileged: true
       env:
@@ -42,10 +39,15 @@ spec:
       volumeMounts:
         - mountPath: /storage
           name: storage
+        - mountPath: /dev/kvm
+          name: dev-kvm
   volumes:
     - name: storage
       persistentVolumeClaim:
         claimName: windows-pvc
+    - name: dev-kvm
+      hostPath:
+        path: /dev/kvm
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -62,14 +62,11 @@ spec:
       protocol: TCP
       port: 8006
       targetPort: 8006
-      nodePort: 48006
     - name: tcp-3389
       protocol: TCP
       port: 3389
       targetPort: 3389
-      nodePort: 43389
     - name: udp-3389
       protocol: UDP
       port: 3389
       targetPort: 3389
-      nodePort: 43388


### PR DESCRIPTION
Removed static node ports. User can add them in range or let the system assign the. Or use a load balancer.

Remove kubevirt dep as in comment here https://github.com/dockur/windows/pull/304#discussion_r1637455331