### PR TITLE
Pull Request: 2024/7/17 6:32pm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
-COPY --from=qemux/qemu-docker:5.16 / /
+COPY --from=qemux/qemu-docker:latest / /
 
 ARG VERSION_ARG="0.0"
 ARG DEBCONF_NOWARNINGS="yes"
@@ -27,15 +27,15 @@ RUN set -eu && \
 COPY --chmod=755 ./src /run/
 COPY --chmod=755 ./assets /run/assets
 
-ADD --chmod=755 https://raw.githubusercontent.com/christgau/wsdd/v0.8/src/wsdd.py /usr/sbin/wsdd
+ADD --chmod=755 https://raw.githubusercontent.com/christgau/wsdd/master/src/wsdd.py /usr/sbin/wsdd
 ADD --chmod=664 https://github.com/qemus/virtiso/releases/download/v0.1.248/virtio-win-0.1.248.tar.xz /drivers.txz
 
 EXPOSE 8006 3389
 VOLUME /storage
 
-ENV RAM_SIZE "4G"
-ENV CPU_CORES "2"
-ENV DISK_SIZE "64G"
-ENV VERSION "win11"
+ENV RAM_SIZE "8G"
+ENV CPU_CORES "8"
+ENV DISK_SIZE "512G"
+ENV VERSION "win11e"
 
 ENTRYPOINT ["/usr/bin/tini", "-s", "/run/entry.sh"]

--- a/compose.yml
+++ b/compose.yml
@@ -3,9 +3,10 @@ services:
     image: dockurr/windows
     container_name: windows
     environment:
-      VERSION: "win11"
+      VERSION: "win11e"
     devices:
       - /dev/kvm
+      - /dev/net/tun
     cap_add:
       - NET_ADMIN
     ports:

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -7,7 +7,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 64Gi
+      storage: 512Gi
 ---
 apiVersion: v1
 kind: Pod
@@ -30,17 +30,21 @@ spec:
       securityContext:
         privileged: true
       env:
+        - name: VERSION
+          value: "win11e"
         - name: RAM_SIZE
-          value: 4G
+          value: 8G
         - name: CPU_CORES
-          value: "2"
+          value: "8"
         - name: DISK_SIZE
-          value: "64G"
+          value: "512G"
       volumeMounts:
         - mountPath: /storage
           name: storage
         - mountPath: /dev/kvm
           name: dev-kvm
+        - mountPath: /dev/net/tun
+          name: dev-net-tun
   volumes:
     - name: storage
       persistentVolumeClaim:
@@ -48,6 +52,9 @@ spec:
     - name: dev-kvm
       hostPath:
         path: /dev/kvm
+    - name: dev-net-tun
+      hostPath:
+        path: /dev/net/tun
 ---
 apiVersion: v1
 kind: Service

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 
 </div></h1>
 
-Windows inside a Docker container.
+Windows insides Docker container.
 
 ## Features ✨
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Windows inside a Docker container.
 
 ## Video 📺
 
-[![Youtube](https://img.youtube.com/vi/xhGYobuG508/0.jpg)](https://www.youtube.com/watch?v=xhGYobuG508)
+[![Youtube](https://img.youtube.com/vi/xhGYobuG508/0.jpg)](https://youtu.be/xhGYobuG508)
 
 ## Usage 🐳
 
@@ -35,9 +35,10 @@ services:
     image: dockurr/windows
     container_name: windows
     environment:
-      VERSION: "win11"
+      VERSION: "win11e"
     devices:
       - /dev/kvm
+      - /dev/net/tun
     cap_add:
       - NET_ADMIN
     ports:
@@ -50,7 +51,7 @@ services:
 Via Docker CLI:
 
 ```bash
-docker run -it --rm -p 8006:8006 --device=/dev/kvm --cap-add NET_ADMIN --stop-timeout 120 dockurr/windows
+docker run -it --rm -p 8006:8006 --device=/dev/kvm --device=/dev/net/tun --cap-add NET_ADMIN --stop-timeout 120 dockurr/windows
 ```
 
 Via Kubernetes:
@@ -63,7 +64,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I use it?
 
-  Very simple! These are the steps:
+  Simple! Steps below:
   
   - Start the container and connect to [port 8006](http://localhost:8006) using your web browser.
 
@@ -75,11 +76,11 @@ kubectl apply -f kubernetes.yml
 
 ### How do I select the Windows version?
 
-  By default, Windows 11 will be installed. But you can add the `VERSION` environment variable to your compose file, in order to specify an alternative Windows version to be downloaded:
+  By default, Windows 11 Enterprise will be installed. But you can add the `VERSION` environment variable to your compose file, in order to specify an alternative Windows version to be downloaded:
 
   ```yaml
   environment:
-    VERSION: "win11"
+    VERSION: "win11e"
   ```
 
   Select from the values below:
@@ -148,11 +149,11 @@ kubectl apply -f kubernetes.yml
 
 ### How do I change the size of the disk?
 
-  To expand the default size of 64 GB, add the `DISK_SIZE` setting to your compose file and set it to your preferred capacity:
+  To expand the default size of 512GB, add the `DISK_SIZE` setting to your compose file and set it to your preferred capacity:
 
   ```yaml
   environment:
-    DISK_SIZE: "256G"
+    DISK_SIZE: "1T"
   ```
   
 > [!TIP]
@@ -168,7 +169,7 @@ kubectl apply -f kubernetes.yml
   ```
 
   The example folder `/home/user/example` will be available as ` \\host.lan\Data`.
-  
+ 
 > [!TIP]
 > You can map this path to a drive letter in Windows, for easier access.
 
@@ -192,7 +193,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I run a script after installation?
 
-  To run your own script after installation, you can create a file called `install.bat` and place it in a folder together with any additional files it needs (software to be installed for example). Then bind that folder in your compose file like this:
+  To run your own script after installation, you create a file called `install.bat` and place it in a folder together with any additional files it needs (software to be installed for example). Then bind that folder in your compose file like this:
 
   ```yaml
   volumes:
@@ -203,7 +204,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I perform a manual installation?
 
-  It's best to stick to the automatic installation, as it adjusts various settings to prevent common issues when running Windows inside a virtual environment.
+  It's best sticking to automatic installation, as adjusting various settings to prevent common issues when running Windows inside a virtual environment.
 
   However, if you insist on performing the installation manually, add the following environment variable to your compose file:
 
@@ -214,14 +215,14 @@ kubectl apply -f kubernetes.yml
 
 ### How do I change the amount of CPU or RAM?
 
-  By default, the container will be allowed to use a maximum of 2 CPU cores and 4 GB of RAM.
+  By default, the container will be allowed to use a maximum of 8 CPU cores and 8 GB of RAM.
 
   If you want to adjust this, you can specify the desired amount using the following environment variables:
 
   ```yaml
   environment:
-    RAM_SIZE: "8G"
-    CPU_CORES: "4"
+    RAM_SIZE: "16G"
+    CPU_CORES: "32"
   ```
 
 ### How do I configure the username and password?
@@ -307,9 +308,11 @@ kubectl apply -f kubernetes.yml
   environment:
     DISK2_SIZE: "32G"
     DISK3_SIZE: "64G"
+...
   volumes:
     - /home/example:/storage2
     - /mnt/data/example:/storage3
+...
   ```
 
 ### How do I pass-through a disk?
@@ -320,6 +323,7 @@ kubectl apply -f kubernetes.yml
   devices:
     - /dev/sdb:/disk1
     - /dev/sdc:/disk2
+...
   ```
 
   Use `/disk1` if you want it to become your main drive, and use `/disk2` and higher to add them as secondary drives.
@@ -349,7 +353,7 @@ kubectl apply -f kubernetes.yml
 
   If you receive an error from `kvm-ok` indicating that KVM acceleration can't be used, please check whether:
 
-  - the virtualization extensions (`Intel VT-x` or `AMD SVM`) are enabled in your BIOS.
+  - the virtualization extensions (`Intel VT-x` or `AMD SVM`) are enabled in your UEFI BIOS.
 
   - you are running an operating system that supports them, like Linux or Windows 11 (macOS and Windows 10 do not unfortunately).
 

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ kubectl apply -f kubernetes.yml
   | `tiny10`  | Tiny 10                  | 3.6 GB   |
 
 > [!TIP]
-> To install ARM64 versions of Windows use [dockur/windows-arm](https://github.com/dockur/windows-arm/).
+> Installing ARM64 versions of Windows? Heads to [dockur/windows-arm](https://github.com/dockur/windows-arm/)!
 
 ### How do I select the Windows language?
 
@@ -134,7 +134,7 @@ kubectl apply -f kubernetes.yml
   ```
 
 > [!NOTE]  
->  Changing these values will have no effect after the installation has been performed already. Use the control panel inside Windows in that case.
+>  Changing these values has no effect after the installation has been performed already. Use settings inside Windows in case.
 
 ### How do I change the storage location?
 
@@ -149,7 +149,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I change the size of the disk?
 
-  To expand the default size of 512GB, add the `DISK_SIZE` setting to your compose file and set it to your preferred capacity:
+  To expand the default size of 512 GB, add the `DISK_SIZE` setting to your compose file and set it to your preferred capacity:
 
   ```yaml
   environment:
@@ -157,50 +157,50 @@ kubectl apply -f kubernetes.yml
   ```
   
 > [!TIP]
-> This can also be used to resize the existing disk to a larger capacity without any data loss.
+> This also used resizing the existing disk to a larger capacity without any data loss.
 
 ### How do I share files with the host?
 
-  Open 'File Explorer' and click on the 'Network' section, you will see a computer called `host.lan`. Double-click it and it will show a folder called `Data`, which can be binded to any folder on your host via the compose file:
+  Open 'File Explorer', click the 'Network' section, seeing a computer called `host.lan`. Double-click and shows a folder called `Data`, which binds to any folder on your host via the compose file:
 
   ```yaml
   volumes:
     -  /home/user/example:/shared
   ```
 
-  The example folder `/home/user/example` will be available as ` \\host.lan\Data`.
+  Your example folder `/home/user/example` availables ` \\host.lan\Data`.
  
 > [!TIP]
-> You can map this path to a drive letter in Windows, for easier access.
+> You may map this path to a drive letter in Windows, for easier access.
 
 ### How do I install a custom image?
 
-  In order to download an unsupported ISO image that is not selectable from the list above, specify the URL of that ISO in the `VERSION` environment variable, for example:
+  In order to download an unsupported ISO image that is not selectable from the list above, specify one of your URL to ISO in the `VERSION` environment variable, for example:
   
   ```yaml
   environment:
     VERSION: "https://example.com/win.iso"
   ```
 
-  Alternatively, you can also skip the download and use a local file instead, by binding it in your compose file in this way:
+  Alternatively, you skip downloading and use a local file instead, by binding it in your compose file in this way:
   
   ```yaml
   volumes:
     - /home/user/example.iso:/custom.iso
   ```
 
-  Replace the example path `/home/user/example.iso` with the filename of your desired ISO file, the value of `VERSION` will be ignored in this case.
+  Replace the example path `/home/user/example.iso` with the filename of your desired ISO file, the value of `VERSION` will be ignored in your case.
 
 ### How do I run a script after installation?
 
-  To run your own script after installation, you create a file called `install.bat` and place it in a folder together with any additional files it needs (software to be installed for example). Then bind that folder in your compose file like this:
+  To run your own script after installation, create your file called `install.bat` and place in a folder together with any additional files it needs (software to be installed for example). Then bind that folder in your compose file like this:
 
   ```yaml
   volumes:
     -  /home/user/example:/oem
   ```
 
-  The example folder `/home/user/example` will be copied to `C:\OEM` during installation and the containing `install.bat` will be executed during the last step.
+  Your example folder `/home/user/example` copied to `C:\OEM` during installation and the containing `install.bat` will be executed during the last step.
 
 ### How do I perform a manual installation?
 
@@ -215,9 +215,9 @@ kubectl apply -f kubernetes.yml
 
 ### How do I change the amount of CPU or RAM?
 
-  By default, the container will be allowed to use a maximum of 8 CPU cores and 8 GB of RAM.
+  By default, container allows using maximum of 8 CPU cores and 8 GB of RAM.
 
-  If you want to adjust this, you can specify the desired amount using the following environment variables:
+  Want to adjust this? Specify the desired amount using the following environment variables:
 
   ```yaml
   environment:
@@ -225,11 +225,11 @@ kubectl apply -f kubernetes.yml
     CPU_CORES: "32"
   ```
 
-### How do I configure the username and password?
+### How do I configure my username and password?
 
-  By default, a user called `Docker` is created during the installation, with an empty password.
+  By default, you called `Docker`, created during the installation, with empty password.
 
-  If you want to use different credentials, you can change them in your compose file:
+  Want to use different credentials? Change them in your compose file:
 
   ```yaml
   environment:
@@ -239,17 +239,17 @@ kubectl apply -f kubernetes.yml
 
 ### How do I connect using RDP?
 
-  The web-viewer is mainly meant to be used during installation, as its picture quality is low, and it has no audio or clipboard for example.
+  Our web-viewer's mainly meant to be used during installation, as our picture quality are low, and has no audio or clipboard for example.
 
-  So for a better experience you can connect using any Microsoft Remote Desktop client to the IP of the container, using the username `Docker` and by leaving the password empty.
+  For better experience, please connect using any Microsoft Remote Desktop app client to the IP of your container, using username `Docker` and leaving password empty.
 
-  There is a RDP client for [Android](https://play.google.com/store/apps/details?id=com.microsoft.rdc.androidx) available from the Play Store and one for [iOS](https://apps.apple.com/nl/app/microsoft-remote-desktop/id714464092?l=en-GB) in the Apple Store. For Linux you can use [FreeRDP](https://www.freerdp.com/) and on Windows just type `mstsc` in the search box.
+  There is a RDP client for [Android](https://play.google.com/store/apps/details?id=com.microsoft.rdc.androidx) available from the Play Store and one for [iOS](https://apps.apple.com/app/microsoft-remote-desktop/id714464092) in the Apple App Store. For Linux feel free using [FreeRDP](https://www.freerdp.com/) and on Windows just type `mstsc` in the search box.
 
 ### How do I assign an individual IP address to the container?
 
-  By default, the container uses bridge networking, which shares the IP address with the host. 
+  By default, you use bridged networking, shares your IP address with your host. 
 
-  If you want to assign an individual IP address to the container, you can create a macvlan network as follows:
+  Want assigning an individual IP address to the container? Create macvlan network as follows:
 
   ```bash
   docker network create -d macvlan \
@@ -259,9 +259,9 @@ kubectl apply -f kubernetes.yml
       -o parent=eth0 vlan
   ```
   
-  Be sure to modify these values to match your local subnet. 
+  Be sure modifying these values, matching your local subnet. 
 
-  Once you have created the network, change your compose file to look as follows:
+  Once you created your network, change your compose file looking as follows:
 
   ```yaml
   services:
@@ -277,14 +277,14 @@ kubectl apply -f kubernetes.yml
       external: true
   ```
  
-  An added benefit of this approach is that you won't have to perform any port mapping anymore, since all ports will be exposed by default.
+  An adds benefit to approaches is won't have performing any port mapping anymore, since all ports are exposed by default.
 
 > [!IMPORTANT]  
-> This IP address won't be accessible from the Docker host due to the design of macvlan, which doesn't permit communication between the two. If this is a concern, you need to create a [second macvlan](https://blog.oddbit.com/post/2018-03-12-using-docker-macvlan-networks/#host-access) as a workaround.
+> This IP address won't be accessible from the Docker host due to the design of macvlan, which doesn't permit communication between the two. If this is a concern, you need to create a [second macvlan](https://blog.oddbit.com/post/2018-03-12-using-docker-macvlan-networks/#host-access) as current workaround.
 
-### How can Windows acquire an IP address from my router?
+### How my Windows acquiring an IP address from my router?
 
-  After configuring the container for [macvlan](#how-do-i-assign-an-individual-ip-address-to-the-container), it is possible for Windows to become part of your home network by requesting an IP from your router, just like a real PC.
+  After configuring your container for [macvlan](#how-do-i-assign-an-individual-ip-address-to-the-container), possibles for Windows becoming part of your home network by requesting an IP from your router, just like a real PC.
 
   To enable this mode, add the following lines to your compose file:
 
@@ -302,7 +302,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I add multiple disks?
 
-  To create additional disks, modify your compose file like this:
+  Really to create your additional disks? Modify compose file like this:
   
   ```yaml
   environment:
@@ -317,7 +317,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I pass-through a disk?
 
-  It is possible to pass-through disk devices directly by adding them to your compose file in this way:
+  Possibles passing-through disk devices directly by adding them in your compose file this way:
 
   ```yaml
   devices:
@@ -326,11 +326,11 @@ kubectl apply -f kubernetes.yml
 ...
   ```
 
-  Use `/disk1` if you want it to become your main drive, and use `/disk2` and higher to add them as secondary drives.
+  Use `/disk1` if you want it to become your main drive, and use `/disk2` and higher to add them as futher drives.
 
 ### How do I pass-through a USB device?
 
-  To pass-through a USB device, first lookup its vendor and product id via the `lsusb` command, then add them to your compose file like this:
+  Passing-through some USB device? First, lookup its vendor and product id via the `lsusb` command, then add them to your compose file like this:
 
   ```yaml
   environment:
@@ -340,20 +340,20 @@ kubectl apply -f kubernetes.yml
   ```
 
 > [!IMPORTANT]
-> If the device is a USB disk drive, please wait until after the installation is completed before connecting it. Otherwise the installation may fail, as the order of the disks can get rearranged.
+> If your device is USB disk drive, please wait until after the installation is completed before connecting it. Or installation fails, as ordering the disks can get rearranged.
 
 ### How do I verify if my system supports KVM?
 
-  To verify that your system supports KVM, run the following commands:
+  To verify that your system supports KVM, run followings:
 
   ```bash
   sudo apt install cpu-checker
   sudo kvm-ok
   ```
 
-  If you receive an error from `kvm-ok` indicating that KVM acceleration can't be used, please check whether:
+  You may receive errors from `kvm-ok` indicating KVM acceleration can't be used, please check whether:
 
-  - the virtualization extensions (`Intel VT-x` or `AMD SVM`) are enabled in your UEFI BIOS.
+  - the virtualization extensions (`Intel VT-x` or `AMD SVM`) are enabled in your UEFI.
 
   - you are running an operating system that supports them, like Linux or Windows 11 (macOS and Windows 10 do not unfortunately).
 
@@ -361,22 +361,22 @@ kubectl apply -f kubernetes.yml
 
   - you are not using a cloud provider, as most of them do not allow nested virtualization for their VPS's.
 
-  If you didn't receive any error from `kvm-ok` at all, but the container still complains that `/dev/kvm` is missing, it might help to add `privileged: true` to your compose file (or `--privileged` to your `run` command), to rule out any permission issue.
+  If you didn't receive any error from `kvm-ok` at all, but the container still complains that `/dev/kvm` is missing, it might helped by adding `privileged: true` in your compose file (or `--privileged` in your `run` command), ruling out any permission issue.
 
 ### How do I run macOS in a container?
 
-  You can use [dockur/macos](https://github.com/dockur/macos) for that. It shares many of the same features, except for the automatic installation.
+  Feel free using [dockur/macos](https://github.com/dockur/macos) for that shares many of same features, except automatic installation.
 
 ### Is this project legal?
 
-  Yes, this project contains only open-source code and does not distribute any copyrighted material. Any product keys found in the code are just generic placeholders provided by Microsoft for trial purposes. So under all applicable laws, this project will be considered legal.
+  Yes, our project contains only open-source code and does not distribute any copyrighted material. Any product keys found in the code are just generic placeholders provided by Microsoft for trial purposes. So under all applicable laws, we considered legal.
 
 ## Stars 🌟
 [![Stars](https://starchart.cc/dockur/windows.svg?variant=adaptive)](https://starchart.cc/dockur/windows)
 
 ## Disclaimer ⚖️
 
-*The product names, logos, brands, and other trademarks referred to within this project are the property of their respective trademark holders. This project is not affiliated, sponsored, or endorsed by Microsoft Corporation.*
+*The product names, logos, brands, and other trademarks referred to within us are the property of their respective trademark holders. This project not affiliated, sponsored, or endorsed by Microsoft Corporation.*
 
 [build_url]: https://github.com/dockur/windows/
 [hub_url]: https://hub.docker.com/r/dockurr/windows/

--- a/readme.md
+++ b/readme.md
@@ -114,18 +114,18 @@ kubectl apply -f kubernetes.yml
 
 ### How do I select the Windows language?
 
-  By default, the English version of Windows will be downloaded. But you can add the `LANGUAGE` environment variable to your compose file, in order to specify an alternative language:
+  By default, the English version of Windows downloadeds. But you adding the `LANGUAGE` environment variable in your compose file, ordering to specify an alternative language:
 
   ```yaml
   environment:
     LANGUAGE: "French"
   ```
   
-  You can choose between: 🇦🇪 Arabic, 🇧🇬 Bulgarian, 🇨🇳 Chinese, 🇭🇷 Croatian, 🇨🇿 Czech, 🇩🇰 Danish, 🇳🇱 Dutch, 🇬🇧 English, 🇪🇪 Estionian, 🇫🇮 Finnish, 🇫🇷 French, 🇩🇪 German, 🇬🇷 Greek, 🇮🇱 Hebrew, 🇭🇺 Hungarian, 🇮🇹 Italian, 🇯🇵 Japanese, 🇰🇷 Korean, 🇱🇻 Latvian, 🇱🇹 Lithuanian, 🇳🇴 Norwegian, 🇵🇱 Polish, 🇵🇹 Portuguese, 🇷🇴 Romanian, 🇷🇺 Russian, 🇷🇸 Serbian, 🇸🇰 Slovak, 🇸🇮 Slovenian, 🇪🇸 Spanish, 🇸🇪 Swedish, 🇹🇭 Thai, 🇹🇷 Turkish and 🇺🇦 Ukrainian.
+  You choose between: 🇦🇪 Arabic, 🇧🇬 Bulgarian, 🇨🇳 Chinese, 🇭🇷 Croatian, 🇨🇿 Czech, 🇩🇰 Danish, 🇳🇱 Dutch, 🇬🇧 English, 🇪🇪 Estionian, 🇫🇮 Finnish, 🇫🇷 French, 🇩🇪 German, 🇬🇷 Greek, 🇮🇱 Hebrew, 🇭🇺 Hungarian, 🇮🇹 Italian, 🇯🇵 Japanese, 🇰🇷 Korean, 🇱🇻 Latvian, 🇱🇹 Lithuanian, 🇳🇴 Norwegian, 🇵🇱 Polish, 🇵🇹 Portuguese, 🇷🇴 Romanian, 🇷🇺 Russian, 🇷🇸 Serbian, 🇸🇰 Slovak, 🇸🇮 Slovenian, 🇪🇸 Spanish, 🇸🇪 Swedish, 🇹🇭 Thai, 🇹🇷 Turkish and 🇺🇦 Ukrainian.
 
 ### How do I select the keyboard layout?
 
-  If you want to use a keyboard layout or locale that is not the default for your selected language, you can add the `KEYBOARD` and `REGION` variables with a culture code, like this:
+  Want using keyboard layouts or locales that's not your default for selected language? Add the `KEYBOARD` and `REGION` variables with culture codes, like this:
 
   ```yaml
   environment:
@@ -138,18 +138,18 @@ kubectl apply -f kubernetes.yml
 
 ### How do I change the storage location?
 
-  To change the storage location, include the following bind mount in your compose file:
+  Change your storage locations? Include following bind mount in your compose file:
 
   ```yaml
   volumes:
     - /var/win:/storage
   ```
 
-  Replace the example path `/var/win` with the desired storage folder.
+  Replace the example path `/var/win` with your desired storage folder.
 
 ### How do I change the size of the disk?
 
-  To expand the default size of 512 GB, add the `DISK_SIZE` setting to your compose file and set it to your preferred capacity:
+  Expand your default size of 512 GB, add the `DISK_SIZE` setting in your compose file and sets your preferred capacity:
 
   ```yaml
   environment:
@@ -171,25 +171,25 @@ kubectl apply -f kubernetes.yml
   Your example folder `/home/user/example` availables ` \\host.lan\Data`.
  
 > [!TIP]
-> You may map this path to a drive letter in Windows, for easier access.
+> You map this path to a drive letter in Windows, for easier access.
 
 ### How do I install a custom image?
 
-  In order to download an unsupported ISO image that is not selectable from the list above, specify one of your URL to ISO in the `VERSION` environment variable, for example:
+  Ordering downloading an unsupported ISO image that's not selectable from the list above? Specify one of your URL to ISO in the `VERSION` environment variable, for example:
   
   ```yaml
   environment:
     VERSION: "https://example.com/win.iso"
   ```
 
-  Alternatively, you skip downloading and use a local file instead, by binding it in your compose file in this way:
+  Alternatively, you skip downloading and using local file instead, by binding it in your compose file on this way:
   
   ```yaml
   volumes:
     - /home/user/example.iso:/custom.iso
   ```
 
-  Replace the example path `/home/user/example.iso` with the filename of your desired ISO file, the value of `VERSION` will be ignored in your case.
+  Replace the example path `/home/user/example.iso` with the filename of your desired ISO file, the value of `VERSION`, means you,  will ignored in your case.
 
 ### How do I run a script after installation?
 
@@ -200,7 +200,7 @@ kubectl apply -f kubernetes.yml
     -  /home/user/example:/oem
   ```
 
-  Your example folder `/home/user/example` copied to `C:\OEM` during installation and the containing `install.bat` will be executed during the last step.
+  Your example folder `/home/user/example` copied to `C:\OEM` during installation. The containing `install.bat` will executed during last steps.
 
 ### How do I perform a manual installation?
 
@@ -217,7 +217,7 @@ kubectl apply -f kubernetes.yml
 
   By default, container allows using maximum of 8 CPU cores and 8 GB of RAM.
 
-  Want to adjust this? Specify the desired amount using the following environment variables:
+  Want to adjust this? Specify the desired amount using following environment variables:
 
   ```yaml
   environment:
@@ -227,9 +227,9 @@ kubectl apply -f kubernetes.yml
 
 ### How do I configure my username and password?
 
-  By default, you called `Docker`, created during the installation, with empty password.
+  By default, you called `Docker`, created during the installation, without password.
 
-  Want to use different credentials? Change them in your compose file:
+  Want using different credentials? Change them in your compose file:
 
   ```yaml
   environment:
@@ -280,7 +280,7 @@ kubectl apply -f kubernetes.yml
   An adds benefit to approaches is won't have performing any port mapping anymore, since all ports are exposed by default.
 
 > [!IMPORTANT]  
-> This IP address won't be accessible from the Docker host due to the design of macvlan, which doesn't permit communication between the two. If this is a concern, you need to create a [second macvlan](https://blog.oddbit.com/post/2018-03-12-using-docker-macvlan-networks/#host-access) as current workaround.
+> This IP address won't be accessible from the Docker host due to design of macvlan, which doesn't permit communication between the two. If this is a concern, you need to create a [second macvlan](https://blog.oddbit.com/post/2018-03-12-using-docker-macvlan-networks/#host-access) as current workaround.
 
 ### How my Windows acquiring an IP address from my router?
 
@@ -302,7 +302,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I add multiple disks?
 
-  Really to create your additional disks? Modify compose file like this:
+  Really creating your additional disks? Modify compose file like this:
   
   ```yaml
   environment:
@@ -317,7 +317,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I pass-through a disk?
 
-  Possibles passing-through disk devices directly by adding them in your compose file this way:
+  Possibles passing-through disk devices directly, adding them in your compose file this way:
 
   ```yaml
   devices:
@@ -326,7 +326,7 @@ kubectl apply -f kubernetes.yml
 ...
   ```
 
-  Use `/disk1` if you want it to become your main drive, and use `/disk2` and higher to add them as futher drives.
+  Use `/disk1` if you want it to become your main drive, and use `/disk2` and higher, adding them as futher drives.
 
 ### How do I pass-through a USB device?
 
@@ -344,7 +344,7 @@ kubectl apply -f kubernetes.yml
 
 ### How do I verify if my system supports KVM?
 
-  To verify that your system supports KVM, run followings:
+  Verifying your system supports KVM? Run followings:
 
   ```bash
   sudo apt install cpu-checker
@@ -376,7 +376,7 @@ kubectl apply -f kubernetes.yml
 
 ## Disclaimer ⚖️
 
-*The product names, logos, brands, and other trademarks referred to within us are the property of their respective trademark holders. This project not affiliated, sponsored, or endorsed by Microsoft Corporation.*
+*The product names, logos, brands, and other trademarks referres within us are the property of their respective trademark holders. This project not affiliated, sponsored, or endorsed by Microsoft Corporation.*
 
 [build_url]: https://github.com/dockur/windows/
 [hub_url]: https://hub.docker.com/r/dockurr/windows/


### PR DESCRIPTION
This time, we stick qemux/qemu-docker to always latest version. Keep wsdd to master branch. Updates default machine specs, to following:

- RAM: 8GB
- CPU Cores: 8
- Disk size: 512GB
- Windows Edition: Windows 11 Enterprise

README.md Changes following:

- Installs Windows 11 Enterprise by default.
- Updates default machine specs, to following and adds /dev/net/tun:
  - RAM: 8GB
  - CPU Cores: 8
  - Disk size: 512GB
- Prettify reading in README.