### PR TITLE
add tun device

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ services:
     environment:
       VERSION: "11"
     devices:
+      - /dev/net/tun:/dev/net/tun
       - /dev/kvm
     cap_add:
       - NET_ADMIN


### PR DESCRIPTION
required for `containerd.io 1.7.24`. Otherwise Samba can't be used.