### PR TITLE
Update win2019-hv.xml: Disable Hyper-V role

### DIFF
--- a/assets/win2019-hv.xml
+++ b/assets/win2019-hv.xml
@@ -159,6 +159,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>dism.exe /online /Disable-Feature /FeatureName:Microsoft-Hyper-V /NoRestart</Path>
+          <Description>Disable Hyper-V role</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">


### PR DESCRIPTION
When you use Windows 2019 Hyper-V free inside a container with KVM you are using nested virtualization. This slows down the system significantly (especially with WSL2). This change in the configuration disables the role when configuring it. You can enable it later manually if you really need nested virtualization.