### PR TITLE
fix: wimlib-imagex info returns UTF-16LE but is interpreted as UTF8

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -615,9 +615,7 @@ detectImage() {
     warn "failed to locate 'install.wim' or 'install.esd' in ISO image, $FB" && return 1
   fi
 
-  wimlib-imagex info -xml "$wim" > wimxml.xml
-  iconv -f UTF-16LE -t UTF-8 wimxml.xml -o wimxmlutf8.xml
-  info=$(cat wimxmlutf8.xml)
+  info=$(wimlib-imagex info -xml "$wim" | iconv -f UTF-16LE -t UTF-8)
   checkPlatform "$info" || exit 67
 
   DETECTED=$(detectVersion "$info")


### PR DESCRIPTION
In my case where I had used a custom.iso image, the sed command `name=$(sed -n "/$tag/{s/.*<$tag>\(.*\)<\/$tag>.*/\1/;p}" <<< "$xml")` in the selectVersion function (install.sh) did not work properly.

The reason was that the line `info=$(wimlib-imagex info -xml "$wim" | tr -d '\000')` in install.sh returns UTF-16LE coded data but it is beeing interpreted afterwards as UTF8 coded data.

it is maybe not the best way to write a file, change the coding and read it up again, but my bash knowledge is limited