### PR TITLE
build: add `syntax` parser directive to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG VERSION_ARG="latest"
 FROM scratch AS build-amd64
 


### PR DESCRIPTION
## Summary

Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://github.com/dockur/windows/blob/master/Dockerfile/).

## Why?

To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend.