### PR TITLE
feat: Add Windows 11 25H2 download mirror

### DIFF
--- a/src/define.sh
+++ b/src/define.sh
@@ -724,6 +724,7 @@ getMido() {
     "win11x64" )
       size=5819484160
       sum="b56b911bf18a2ceaeb3904d87e7c770bdf92d3099599d61ac2497b91bf190b11"
+      url="https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENT_CONSUMER_x64FRE_en-us.iso"
       ;;
     "win11x64-enterprise-eval" )
       size=5387960320


### PR DESCRIPTION
Added download URL for Windows 11 x64.