### PR TITLE
Add SPICE support by installing qemu-system-modules-spice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eu && \
         dos2unix \
         cabextract \
         libxml2-utils \
-        libarchive-tools && \
+        libarchive-tools \
+        qemu-system-modules-spice && \
     wget "https://github.com/gershnik/wsdd-native/releases/download/v1.22/wsddn_1.22_${TARGETARCH}.deb" -O /tmp/wsddn.deb -q && \
     dpkg -i /tmp/wsddn.deb && \
     apt-get clean && \


### PR DESCRIPTION
## Summary

This PR adds the `qemu-system-modules-spice` package to the Docker image, enabling SPICE protocol support for enhanced VM interaction capabilities.

## Problem

Currently, users attempting to use SPICE with the container encounter errors:
```
ERROR: qemu-system-x86_64: -spice port=5930,addr=0.0.0.0,disable-ticketing: There is no option group 'spice'
qemu-system-x86_64: -spice port=5930,addr=0.0.0.0,disable-ticketing: Perhaps you want to install qemu-system-modules-spice package?
```

This limitation blocks several important use cases:
- **Audio device passthrough** - Users cannot pass through microphones or speakers to the Windows VM (#1478)
- **GPU passthrough with proper input handling** - SPICE is essential for keyboard and mouse functionality when using GPU passthrough (#22)
- **Looking Glass integration** - SPICE is required for proper operation of Looking Glass, which provides low-latency display for GPU-passthrough scenarios

## Solution

The fix is straightforward: install the `qemu-system-modules-spice` package alongside other dependencies. This single-line change enables QEMU's `-spice` option without affecting existing functionality.

## Use Cases

This change enables users to:
1. **Pass through audio devices** - Access real microphone/speaker hardware in Windows (not just RDP's remote audio)
2. **Use GPU passthrough effectively** - Combined with Looking Glass for near-native graphics performance with proper input device handling
3. **Connect via SPICE protocol** - Alternative to RDP with better device support

## Testing

The SPICE module has been successfully used in modified builds of this image, as demonstrated in community implementations: https://www.youtube.com/watch?v=koNym2aW7Js

## Impact

- **Backward compatible** - Simply adds an optional package; existing functionality unchanged
- **Small footprint** - Minimal increase in image size