### PR TITLE
refactor: replace duplicated PID cleanup with loop

### DIFF
--- a/src/power.sh
+++ b/src/power.sh
@@ -76,6 +76,12 @@ finish() {
   local pid
   local cnt=0
   local reason=$1
+  local pids=(
+        "/var/run/tpm.pid"
+        "/var/run/wsdd.pid"
+        "/var/run/samba/nmbd.pid"
+        "/var/run/samba/smbd.pid"
+      )
 
   touch "$QEMU_END"
 
@@ -114,21 +120,12 @@ finish() {
     fi
   fi
 
-  pid="/var/run/tpm.pid"
-  [ -s "$pid" ] && pKill "$(<"$pid")"
-  rm -f "$pid"
-
-  pid="/var/run/wsdd.pid"
-  [ -s "$pid" ] && pKill "$(<"$pid")"
-  rm -f "$pid"
-
-  pid="/var/run/samba/nmbd.pid"
-  [ -s "$pid" ] && pKill "$(<"$pid")"
-  rm -f "$pid"
-
-  pid="/var/run/samba/smbd.pid"
-  [ -s "$pid" ] && pKill "$(<"$pid")"
-  rm -f "$pid"
+  for pid in "${pids[@]}"; do
+      if [[ -s "$pid" ]]; then 
+          pKill "$(cat "$pid")"
+      fi
+      rm -f "$pid"
+  done 
 
   closeNetwork
 


### PR DESCRIPTION
### **refactor: simplify PID cleanup using a loop**

This update replaces the repeated PID cleanup sections with a single loop.
All PID paths are now stored in an array, and the loop handles checking, killing, and removing each file.

#### **What changed**

* Added a `pids` array containing all PID file paths.
* Replaced four duplicated cleanup blocks with one loop.
* Logic remains the same:

  * If the PID file exists and is not empty → kill the process
  * Remove the PID file afterward

#### **Why**

* Cleaner and easier-to-read code
* Less duplication
* Simplifies adding or removing PID files in the future

---