### PR TITLE
fix: Path to "Desktop" folder on Windows XP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/windows/refs/heads/mas
 
 ### How do I share files with the host?
 
-  After installation there will be a folder called `Shared` on your desktop, which can be used to exchange files with the host machine.
+  After installation there will be a folder called `Shared` on your desktop, which can be used to exchange files with the host machine. `Shared` is a link to the `\\host.lan\Data` folder, which can also be accessed directly.
   
   To select a folder on the host for this purpose, include the following bind mount in your compose file:
 

--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/windows/refs/heads/mas
 
 ### How do I share files with the host?
 
-  After installation there will be a folder called `Shared` on your desktop, which can be used to exchange files with the host machine. `Shared` is a link to the `\\host.lan\Data` folder, which can also be accessed directly.
+  After installation there will be a folder called `Shared` on your desktop, which can be used to exchange files with the host machine.
   
   To select a folder on the host for this purpose, include the following bind mount in your compose file:
 

--- a/src/define.sh
+++ b/src/define.sh
@@ -1766,7 +1766,7 @@ prepareInstall() {
           echo ""
           echo "Call Domain.MoveHere(LocalAdminADsPath, \"$username\")"
           echo ""
-          echo "Set oLink = WshShell.CreateShortcut(WshShell.ExpandEnvironmentStrings(\"%userprofile%\\Desktop\\Shared.lnk\"))"
+          echo "Set oLink = WshShell.CreateShortcut(WshShell.SpecialFolders(\"Desktop\") & \"\\Shared.lnk\")"
           echo "With oLink"
           echo "  .TargetPath = \"\\\\host.lan\\Data\""
           echo "  .Save"


### PR DESCRIPTION
See:

- https://learn.microsoft.com/en-us/previous-versions//9x9e7edx(v=vs.85)
- https://learn.microsoft.com/en-us/previous-versions//0ea7b5xe(v=vs.85)
- https://en.wikipedia.org/wiki/Special_folder

Fixes #1624