### PR TITLE
feat: add memory ballooning support

### DIFF
--- a/assets/win10x64-enterprise-eval.xml
+++ b/assets/win10x64-enterprise-eval.xml
@@ -246,6 +246,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>26</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win10x64-enterprise.xml
+++ b/assets/win10x64-enterprise.xml
@@ -249,6 +249,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>26</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win10x64-iot.xml
+++ b/assets/win10x64-iot.xml
@@ -255,6 +255,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>26</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win10x64-ltsc.xml
+++ b/assets/win10x64-ltsc.xml
@@ -252,6 +252,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>26</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win10x64.xml
+++ b/assets/win10x64.xml
@@ -249,6 +249,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>26</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win11x64-enterprise-eval.xml
+++ b/assets/win11x64-enterprise-eval.xml
@@ -269,6 +269,11 @@
           <Path>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</Path>
           <Description>Install VirtIO display driver</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>27</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win11x64-enterprise.xml
+++ b/assets/win11x64-enterprise.xml
@@ -272,6 +272,11 @@
           <Path>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</Path>
           <Description>Install VirtIO display driver</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>27</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win11x64-iot.xml
+++ b/assets/win11x64-iot.xml
@@ -272,6 +272,11 @@
           <Path>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</Path>
           <Description>Install VirtIO display driver</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>27</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win11x64-ltsc.xml
+++ b/assets/win11x64-ltsc.xml
@@ -272,6 +272,11 @@
           <Path>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</Path>
           <Description>Install VirtIO display driver</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>27</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win11x64.xml
+++ b/assets/win11x64.xml
@@ -272,6 +272,11 @@
           <Path>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</Path>
           <Description>Install VirtIO display driver</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>27</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2008r2-eval.xml
+++ b/assets/win2008r2-eval.xml
@@ -154,6 +154,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2008r2.xml
+++ b/assets/win2008r2.xml
@@ -157,6 +157,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2012r2-eval.xml
+++ b/assets/win2012r2-eval.xml
@@ -155,6 +155,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2012r2.xml
+++ b/assets/win2012r2.xml
@@ -158,6 +158,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2016-eval.xml
+++ b/assets/win2016-eval.xml
@@ -155,6 +155,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2016.xml
+++ b/assets/win2016.xml
@@ -158,6 +158,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2019-eval.xml
+++ b/assets/win2019-eval.xml
@@ -159,6 +159,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2019-hv.xml
+++ b/assets/win2019-hv.xml
@@ -164,6 +164,11 @@
           <Path>dism.exe /online /Disable-Feature /FeatureName:Microsoft-Hyper-V /NoRestart</Path>
           <Description>Disable Hyper-V role</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2019.xml
+++ b/assets/win2019.xml
@@ -162,6 +162,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2022-eval.xml
+++ b/assets/win2022-eval.xml
@@ -159,6 +159,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2022.xml
+++ b/assets/win2022.xml
@@ -162,6 +162,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2025-eval.xml
+++ b/assets/win2025-eval.xml
@@ -164,6 +164,11 @@
           <Path>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</Path>
           <Description>Install VirtIO display driver</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win2025.xml
+++ b/assets/win2025.xml
@@ -167,6 +167,11 @@
           <Path>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</Path>
           <Description>Install VirtIO display driver</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win7x64-enterprise-eval.xml
+++ b/assets/win7x64-enterprise-eval.xml
@@ -148,6 +148,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win7x64-enterprise.xml
+++ b/assets/win7x64-enterprise.xml
@@ -152,6 +152,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win7x64-ultimate.xml
+++ b/assets/win7x64-ultimate.xml
@@ -152,6 +152,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win7x64.xml
+++ b/assets/win7x64.xml
@@ -152,6 +152,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win7x86-enterprise.xml
+++ b/assets/win7x86-enterprise.xml
@@ -152,6 +152,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win7x86-ultimate.xml
+++ b/assets/win7x86-ultimate.xml
@@ -152,6 +152,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win7x86.xml
+++ b/assets/win7x86.xml
@@ -152,6 +152,15 @@
         </FirewallGroup>
       </FirewallGroups>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win81x64-enterprise-eval.xml
+++ b/assets/win81x64-enterprise-eval.xml
@@ -146,6 +146,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win81x64-enterprise.xml
+++ b/assets/win81x64-enterprise.xml
@@ -149,6 +149,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/win81x64.xml
+++ b/assets/win81x64.xml
@@ -156,6 +156,11 @@
           <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
           <Description>Set Network Location to Home</Description>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/winvistax64-enterprise.xml
+++ b/assets/winvistax64-enterprise.xml
@@ -90,6 +90,15 @@
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <fDenyTSConnections>false</fDenyTSConnections>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/winvistax64-ultimate.xml
+++ b/assets/winvistax64-ultimate.xml
@@ -90,6 +90,15 @@
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <fDenyTSConnections>false</fDenyTSConnections>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/winvistax64.xml
+++ b/assets/winvistax64.xml
@@ -90,6 +90,15 @@
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <fDenyTSConnections>false</fDenyTSConnections>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/winvistax86-enterprise.xml
+++ b/assets/winvistax86-enterprise.xml
@@ -90,6 +90,15 @@
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <fDenyTSConnections>false</fDenyTSConnections>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-International-Core" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/winvistax86-ultimate.xml
+++ b/assets/winvistax86-ultimate.xml
@@ -90,6 +90,15 @@
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <fDenyTSConnections>false</fDenyTSConnections>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-International-Core" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/assets/winvistax86.xml
+++ b/assets/winvistax86.xml
@@ -90,6 +90,15 @@
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <fDenyTSConnections>false</fDenyTSConnections>
     </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>C:\Windows\Drivers\Balloon\blnsvr.exe -i</Path>
+          <Description>Install VirtIO Balloon service</Description>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
   </settings>
   <settings pass="oobeSystem">
     <component name="Microsoft-Windows-International-Core" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/readme.md
+++ b/readme.md
@@ -170,44 +170,6 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/windows/refs/heads/mas
     CPU_CORES: "4"
   ```
 
-### How do I enable dynamic memory allocation?
-
-  By default, the VM is allocated the full amount of RAM configured via `RAM_SIZE` for its entire lifetime.
-
-  If you want the container to dynamically reclaim unused guest RAM based on host memory pressure, you can enable memory ballooning. It is also used to prevent the guest from exceeding the container's memory limit, even when the limit is changed at runtime:
-
-  ```yaml
-  environment:
-    BALLOONING: "Y"
-  ```
-
-  This requires the VirtIO Balloon service to be installed in the guest. For all supported Windows versions, this happens automatically during unattended installation. If you are using a manual installation or an existing guest that was installed before this feature was added, you need to install it manually by running the following command inside the VM:
-
-  ```bat
-  C:\Windows\Drivers\Balloon\blnsvr.exe -i
-  ```
-
-  The following optional variables allow you to tune the ballooning behaviour:
-
-  | **Variable**              | **Default** | **Description**                                                    |
-  |---|---|---|
-  | `BALLOONING`              | _(off)_     | Set to `Y` to enable dynamic memory ballooning                     |
-  | `BALLOONING_MIN_MEM`      | `33%`       | Minimum balloon target, as a percentage of guest max memory (e.g. `33%`) or absolute size (e.g. `2G`) |
-  | `BALLOONING_RAM_THRESHOLD`| `80.0`      | Target host RAM usage percentage; the PI controller aims to keep host usage at or below this value |
-  | `BALLOONING_RAM_THRESHOLD_HARD`| `90.0` | Host RAM usage percentage above which the balloon target may drop below guest RAM usage, inducing guest memory pressure |
-  | `BALLOONING_PSI_PRESSURE` | `10.0`      | Host PSI `avg10` stall percentage at which the PSI ceiling begins to lower the balloon target |
-  | `BALLOONING_PSI_PRESSURE_MAX` | `50.0`  | Host PSI `avg10` stall percentage at which the PSI ceiling reaches the configured minimum balloon target |
-  | `BALLOONING_HYSTERESIS`   | `128M`      | Minimum balloon target change required before a resize is applied, as a percentage (e.g. `2%`) or absolute size (e.g. `256M`) |
-  | `BALLOONING_KP`           | `0.5`       | PI controller proportional gain; higher values react faster but may oscillate |
-  | `BALLOONING_KI`           | `0.05`      | PI controller integral gain; higher values correct steady-state error faster but risk overshoot |
-  | `BALLOONING_INTERVAL`     | `5`         | Polling interval in seconds                                        |
-
-> [!NOTE]
-> Memory ballooning uses Linux PSI (`/proc/pressure/memory`) for progressive pressure detection. Between `BALLOONING_PSI_PRESSURE` and `BALLOONING_PSI_PRESSURE_MAX` the PSI ceiling linearly lowers the maximum balloon target from guest max memory down to the configured minimum. If PSI is unavailable (kernel lacks `CONFIG_PSI`), both thresholds are silently skipped and ballooning continues using host memory usage alone.
-
-> [!WARNING]
-> If the container memory limit is reduced at runtime below the guest VM's current memory usage, the container may be killed by the OOM killer if the ballooning driver cannot reclaim memory from the guest fast enough.
-
 ### How do I configure the username and password?
 
   By default, a user called `Docker` is created and its password is `admin`.

--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,41 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/windows/refs/heads/mas
     CPU_CORES: "4"
   ```
 
+### How do I enable dynamic memory allocation?
+
+  By default, the VM is allocated the full amount of RAM configured via `RAM_SIZE` for its entire lifetime.
+
+  If you want the container to dynamically reclaim unused guest RAM based on host memory pressure, you can enable memory ballooning:
+
+  ```yaml
+  environment:
+    BALLOONING: "Y"
+  ```
+
+  This requires the VirtIO Balloon service to be installed in the guest. For all supported Windows versions, this happens automatically during unattended installation. If you are using a manual installation or an existing guest that was installed before this feature was added, you need to install it manually by running the following command inside the VM:
+
+  ```bat
+  C:\Windows\Drivers\Balloon\blnsvr.exe -i
+  ```
+
+  The following optional variables allow you to tune the ballooning behaviour:
+
+  | **Variable**              | **Default** | **Description**                                                    |
+  |---|---|---|
+  | `BALLOONING`              | _(off)_     | Set to `Y` to enable dynamic memory ballooning                     |
+  | `BALLOONING_MIN_MEM`      | `33%`       | Minimum balloon target, as a percentage of guest max memory (e.g. `33%`) or absolute size (e.g. `2G`) |
+  | `BALLOONING_RAM_THRESHOLD`| `80.0`      | Target host RAM usage percentage; the PI controller aims to keep host usage at or below this value |
+  | `BALLOONING_RAM_THRESHOLD_HARD`| `90.0` | Host RAM usage percentage above which the balloon target may drop below guest RAM usage, inducing guest memory pressure |
+  | `BALLOONING_PSI_PRESSURE` | `10.0`      | Host PSI `avg10` stall percentage at which the PSI ceiling begins to lower the balloon target |
+  | `BALLOONING_PSI_PRESSURE_MAX` | `50.0`  | Host PSI `avg10` stall percentage at which the PSI ceiling reaches the configured minimum balloon target |
+  | `BALLOONING_HYSTERESIS`   | `128M`      | Minimum balloon target change required before a resize is applied, as a percentage (e.g. `2%`) or absolute size (e.g. `256M`) |
+  | `BALLOONING_KP`           | `0.5`       | PI controller proportional gain; higher values react faster but may oscillate |
+  | `BALLOONING_KI`           | `0.05`      | PI controller integral gain; higher values correct steady-state error faster but risk overshoot |
+  | `BALLOONING_INTERVAL`     | `5`         | Polling interval in seconds                                        |
+
+> [!NOTE]
+> Memory ballooning uses Linux PSI (`/proc/pressure/memory`) for progressive pressure detection. Between `BALLOONING_PSI_PRESSURE` and `BALLOONING_PSI_PRESSURE_MAX` the PSI ceiling linearly lowers the maximum balloon target from guest max memory down to the configured minimum. If PSI is unavailable (kernel lacks `CONFIG_PSI`), both thresholds are silently skipped and ballooning continues using host memory usage alone.
+
 ### How do I configure the username and password?
 
   By default, a user called `Docker` is created and its password is `admin`.

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/windows/refs/heads/mas
 
   By default, the VM is allocated the full amount of RAM configured via `RAM_SIZE` for its entire lifetime.
 
-  If you want the container to dynamically reclaim unused guest RAM based on host memory pressure, you can enable memory ballooning:
+  If you want the container to dynamically reclaim unused guest RAM based on host memory pressure, you can enable memory ballooning. It is also used to prevent the guest from exceeding the container's memory limit, even when the limit is changed at runtime:
 
   ```yaml
   environment:
@@ -204,6 +204,9 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/windows/refs/heads/mas
 
 > [!NOTE]
 > Memory ballooning uses Linux PSI (`/proc/pressure/memory`) for progressive pressure detection. Between `BALLOONING_PSI_PRESSURE` and `BALLOONING_PSI_PRESSURE_MAX` the PSI ceiling linearly lowers the maximum balloon target from guest max memory down to the configured minimum. If PSI is unavailable (kernel lacks `CONFIG_PSI`), both thresholds are silently skipped and ballooning continues using host memory usage alone.
+
+> [!WARNING]
+> If the container memory limit is reduced at runtime below the guest VM's current memory usage, the container may be killed by the OOM killer if the ballooning driver cannot reclaim memory from the guest fast enough.
 
 ### How do I configure the username and password?
 

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -24,7 +24,6 @@ cd /run
 . power.sh      # Configure shutdown
 . memory.sh     # Check available memory
 . config.sh     # Configure arguments
-. ballooning.sh # Initialize ballooning
 . finish.sh     # Finish initialization
 
 trap - ERR

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -24,6 +24,7 @@ cd /run
 . power.sh      # Configure shutdown
 . memory.sh     # Check available memory
 . config.sh     # Configure arguments
+. ballooning.sh # Initialize ballooning
 . finish.sh     # Finish initialization
 
 trap - ERR


### PR DESCRIPTION
## Summary

This PR enable the opt-in dynamic memory ballooning support, provided by the base QEMU image PR https://github.com/qemus/qemu/pull/1012, for Windows VMs.

**Currently tested on Windows 11 guests.**

Closes #751

## Changes

**Startup script** — Added the `balloning.sh` script execution from the base image for ballooning initialization.

**Guest driver installation** — all Windows unattended installations now include a setup step that installs the VirtIO Balloon service (`blnsvr.exe -i`).