### PR TITLE
Add optional guest audio streaming to the browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ EOF
 COPY --chmod=755 ./src /run/
 COPY --chmod=755 ./assets /run/assets
 
+# Enable audio streaming (AUDIO=Y): run the audio helper and attach the QEMU
+# audio devices before the arguments are assembled in config.sh (from qemux/qemu).
+RUN sed -i '/^buildArguments$/i if [[ "${AUDIO:-N}" =~ ^[Yy] ]] && [ -x /run/audio.sh ]; then bash /run/audio.sh || true; ARGUMENTS="${ARGUMENTS:-} -audiodev wav,id=snd,path=/run/audio.fifo,out.frequency=48000,out.channels=2,out.format=s16 -device intel-hda -device hda-output,audiodev=snd"; fi' /run/config.sh \
+ && grep -q 'audiodev wav' /run/config.sh
+
 ADD --chmod=664 https://github.com/qemus/virtiso-whql/releases/download/v${VERSION_VIRTIO}-0/virtio-win-${VERSION_VIRTIO}.tar.xz /var/drivers.txz
 
 FROM dockurr/windows-arm:${VERSION_ARG} AS build-arm64

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Windows inside a Docker container.
 - Dynamic memory allocation with memory ballooning
 - USB passthrough and host folder sharing
 - Supports NAT, user-mode, macvlan, and macvtap networking
+- Optional audio streaming from the guest to the browser
 
 ## Video 📺
 
@@ -395,6 +396,17 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/windows/refs/heads/mas
   - Your VPS or cloud provider supports nested virtualization.
 
   If `kvm-ok` succeeds but the container still reports that KVM is unavailable, you can temporarily add `privileged: true` to your Compose file to rule out a permission or device-access issue.
+
+### How do I enable audio?
+
+  Audio is off by default. To stream the guest's audio to the browser, add the following environment variable:
+
+  ```yaml
+  environment:
+    AUDIO: "Y"
+  ```
+
+  Then tick the **Audio** box under Settings → Advanced in the web viewer's toolbar. Audio only streams while that box is checked, so it adds no bandwidth when unused.
 
 ### How do I run macOS in a container?
 

--- a/src/audio-plugin.js
+++ b/src/audio-plugin.js
@@ -1,0 +1,43 @@
+(function () {
+  var EMPTY = new Uint8Array(0);
+  function attach() {
+    var cb = document.getElementById('noVNC_setting_audio');
+    if (!cb) return setTimeout(attach, 300);
+    var ctx = null, ws = null, nextTime = 0, leftover = EMPTY;
+    function stop() {
+      try { if (ws) ws.close(); } catch (e) {}
+      try { if (ctx) ctx.close(); } catch (e) {}
+      ws = null; ctx = null; leftover = EMPTY;
+    }
+    function start() {
+      stop();
+      ctx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 48000 });
+      nextTime = ctx.currentTime + 0.15;
+      ws = new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/audio');
+      ws.binaryType = 'arraybuffer';
+      ws.onmessage = function (e) {
+        if (!ctx) return;
+        var bytes;
+        if (leftover.length) {
+          bytes = new Uint8Array(leftover.length + e.data.byteLength);
+          bytes.set(leftover); bytes.set(new Uint8Array(e.data), leftover.length);
+        } else {
+          bytes = new Uint8Array(e.data);
+        }
+        var usable = bytes.length & ~3;
+        leftover = usable < bytes.length ? bytes.slice(usable) : EMPTY;
+        if (!usable) return;
+        var frames = usable >> 2;
+        var i16 = new Int16Array(bytes.buffer, bytes.byteOffset, usable >> 1);
+        var buf = ctx.createBuffer(2, frames, 48000);
+        var l = buf.getChannelData(0), r = buf.getChannelData(1);
+        for (var i = 0, j = 0; i < frames; i++) { l[i] = i16[j++] / 32768; r[i] = i16[j++] / 32768; }
+        var src = ctx.createBufferSource(); src.buffer = buf; src.connect(ctx.destination);
+        var t = nextTime > ctx.currentTime ? nextTime : ctx.currentTime + 0.02;
+        src.start(t); nextTime = t + buf.duration;
+      };
+    }
+    cb.addEventListener('change', function () { cb.checked ? start() : stop(); });
+  }
+  attach();
+})();

--- a/src/audio-relay.py
+++ b/src/audio-relay.py
@@ -1,0 +1,24 @@
+import os, socket, threading
+FIFO = '/run/audio.fifo'; PORT = 4712
+clients = set(); lock = threading.Lock()
+def accept_loop():
+    srv = socket.socket(); srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(('127.0.0.1', PORT)); srv.listen(16)
+    while True:
+        c, _ = srv.accept()
+        c.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        with lock: clients.add(c)
+threading.Thread(target=accept_loop, daemon=True).start()
+while True:
+    fd = os.open(FIFO, os.O_RDONLY)
+    while True:
+        data = os.read(fd, 4096)
+        if not data: break
+        with lock:
+            for c in list(clients):
+                try: c.sendall(data)
+                except Exception:
+                    clients.discard(c)
+                    try: c.close()
+                    except Exception: pass
+    os.close(fd)

--- a/src/audio.sh
+++ b/src/audio.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+NOVNC=/usr/share/novnc
+cp -f /run/audio-plugin.js "$NOVNC/audio-plugin.js"
+grep -q audio-plugin.js "$NOVNC/vnc.html" || \
+  sed -i 's#</head>#    <script src="audio-plugin.js"></script>\n</head>#' "$NOVNC/vnc.html"
+if ! grep -q noVNC_setting_audio "$NOVNC/vnc.html"; then
+  python3 - "$NOVNC/vnc.html" <<'PY'
+import sys
+f=sys.argv[1]; s=open(f).read()
+a='''                            <li>
+                                <label>
+                                    <input id="noVNC_setting_show_dot" type="checkbox"'''
+b='''                            <li>
+                                <label>
+                                    <input id="noVNC_setting_audio" type="checkbox"
+                                           class="toggle">
+                                    Audio
+                                </label>
+                            </li>
+                            <li><hr></li>
+                            <li>
+                                <label>
+                                    <input id="noVNC_setting_show_dot" type="checkbox"'''
+if a in s: open(f,'w').write(s.replace(a,b,1))
+PY
+fi
+# Locate the active nginx site config (path differs between qemus/qemu and dockur bases)
+NGINX=""
+for c in /etc/nginx/sites-enabled/web.conf /etc/nginx/default.conf /etc/nginx/sites-enabled/default; do
+  [ -f "$c" ] && { NGINX="$c"; break; }
+done
+if [ -n "$NGINX" ] && ! grep -q 'location = /audio' "$NGINX"; then
+  python3 - "$NGINX" <<'PY'
+import sys
+f=sys.argv[1]; s=open(f).read()
+blk='''
+    location = /audio {
+      proxy_http_version 1.1;
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_buffering off;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+      proxy_pass http://127.0.0.1:8007/;
+    }
+'''
+i=s.rstrip().rfind('}')
+open(f,'w').write(s[:i]+blk+'\n}\n')
+PY
+  nginx -s reload 2>/dev/null || true
+fi
+rm -f /run/audio.fifo; mkfifo /run/audio.fifo
+nohup python3 /run/audio-relay.py >/run/audiorelay.log 2>&1 & disown
+printf '#!/bin/sh\nexec nc 127.0.0.1 4712\n' > /run/audiopipe.sh; chmod +x /run/audiopipe.sh
+nohup websocketd --port=8007 --binary=true /run/audiopipe.sh >/run/audiows.log 2>&1 & disown


### PR DESCRIPTION
This adds an optional feature to stream the guest's audio to the web viewer. It's off by default and adds no overhead unless enabled.

## What it does

Set `AUDIO: "Y"` and an **Audio** toggle appears under Settings → Advanced in the web viewer's toolbar. Tick it to hear the guest's audio in the browser tab. Audio only streams while the box is checked, so it adds no bandwidth when unused.

## How it works

- QEMU exposes an emulated Intel HDA card (`-device intel-hda -device hda-output`) whose output is written to a FIFO via a `wav` audiodev.
- A small Python relay (`audio-relay.py`) fans the raw PCM out to any number of connected clients over a `websocketd` endpoint.
- nginx proxies that endpoint at `/audio` (same origin as the viewer, so no extra port to expose).
- A noVNC plugin (`audio-plugin.js`) connects when the toggle is on and plays the stream via the Web Audio API.

Because it's just an emulated HDA device, it's guest-OS-agnostic — no guest driver install is needed (Windows ships the HDA driver), and the same mechanism works for Linux/macOS guests.

## Files

- `src/audio.sh`, `src/audio-relay.py`, `src/audio-plugin.js` — the audio stack
- `Dockerfile` — injects the audio hook into `config.sh` (before `buildArguments`) and the QEMU audio devices into `$ARGUMENTS`, guarded by build-time assertions
- `readme.md` — a Features bullet and a "How do I enable audio?" FAQ entry

## Testing

Built the image and booted Windows 11; confirmed QEMU launches with the audio devices attached and audio plays in the browser through the toolbar toggle. The build fails loudly if the injection point in `config.sh` ever moves.
